### PR TITLE
STYLE: Update native Python package name to itk-ants

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ ITKANTsWasm
     :target: https://github.com/thewtex/ANTsWasm/actions/workflows/build-test-package.yml
     :alt: Build Status
 
-.. image:: https://img.shields.io/pypi/v/itk-antswasm.svg
-    :target: https://pypi.python.org/pypi/itk-antswasm
+.. image:: https://img.shields.io/pypi/v/itk-ants.svg
+    :target: https://pypi.python.org/pypi/itk-ants
     :alt: PyPI Version
 
 .. image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     sys.exit(1)
 
 setup(
-    name='itk-antswasm',
+    name='itk-ants',
     version='0.1.0',
     author='Insight Software Consortium',
     author_email='itk+community@discourse.itk.org',


### PR DESCRIPTION
Avoid confusion with the package that will actually use wasm, which will be called itkwasm-ants.