### PR TITLE
Make the CI green

### DIFF
--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master
+      with:
+        itk-branch: master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "itk-ants"
-version = "0.7.0"
+version = "0.8.1"
 description = "Advanced Normalization Tools in WebAssembly"
 readme = "README.rst"
 license = {file = "LICENSE"}


### PR DESCRIPTION
There were some recent changes to clang-format infrastructure.
Also bumping version number to get it ready for release/wheel creation.